### PR TITLE
Use outfits.openneo-assets.net for outfit images

### DIFF
--- a/dti/models.py
+++ b/dti/models.py
@@ -1155,7 +1155,7 @@ class Outfit(Object):
 
         updated_at = int(self.updated_at.timestamp())
         size_str = str(size or self.size)[-3:]
-        return f"https://impress-2020.openneo.net/outfits/{self.id}/v/{updated_at}/{size_str}.png"
+        return f"https://outfits.openneo-assets.net/outfits/{self.id}/v/{updated_at}/{size_str}.png"
 
     async def read(self, size: Optional[LayerImageSize] = None) -> bytes:
         """|coro|


### PR DESCRIPTION
`outfits.openneo-assets.net` is the more canonical host for outfit images, and we control the traffic differently sometimes.

Right now, we're working on moving outfit image pressure off of Vercel, and we're only really able to control the `outfits.openneo-assets.net` with that level of granularity right now.

So, switching to this host should help Neobot take a bit more pressure off our bill! 💖 and help clean up my logs to help confirm that we've actually switched users over!

I haven't tested this change, but it seems simple enough? But it might be smart to have this code build an outfit image URL once before shipping imo, depending on how cautious you're feeling!

ty friend~ 💜