### PR TITLE
Remove ncTradeValueText from item models and payloads

### DIFF
--- a/dti/constants.py
+++ b/dti/constants.py
@@ -14,7 +14,6 @@ fragment ItemProperties on Item {
   rarityIndex
   isNc
   isPb
-  ncTradeValueText
   numUsersOfferingThis
   numUsersSeekingThis
 }"""

--- a/dti/models.py
+++ b/dti/models.py
@@ -730,8 +730,6 @@ class Item(Object):
         The kind of item this is. Can be `NC` for Neocash, `NP` for Neopoint items, or `PB` for paintbrush items.
     rarity: :class:`int`
         The item's rarity on Neopets.
-    nc_value_text: Optional[:class:`str`]
-        The item's NC trade value. Can be None if the item is not NC, or if it has not been valued yet. Values courtesy of neopets.com/~owls
     users_offering: :class:`int`
         The number of users offering this item in trade lists.
     users_seeking: :class:`int`
@@ -746,7 +744,6 @@ class Item(Object):
         "id",
         "kind",
         "name",
-        "nc_value_text",
         "rarity",
         "thumbnail_url",
         "users_offering",
@@ -760,7 +757,6 @@ class Item(Object):
         thumbnail_url: str
         kind: ItemKind
         rarity: int
-        nc_value_text: str | None
         users_seeking: int
         users_offering: int
 
@@ -772,7 +768,6 @@ class Item(Object):
         self.thumbnail_url: str = utils.url_sanitizer(data["thumbnailUrl"])
         self._appearance: ItemAppearance | None = None
         self.appearance = data.get("appearanceOn")
-        self.nc_value_text: str | None = data["ncTradeValueText"]
         self.kind: ItemKind
         self.users_seeking = data["numUsersSeekingThis"]
         self.users_offering = data["numUsersOfferingThis"]

--- a/dti/types/__init__.py
+++ b/dti/types/__init__.py
@@ -61,7 +61,6 @@ class BaseItemPayload(_BaseObject):
     isNc: bool
     isPb: bool
     rarityIndex: str
-    ncTradeValueText: str | None
     numUsersOfferingThis: int
     numUsersSeekingThis: int
 

--- a/tests/payloads/client_fetch_outfit.json
+++ b/tests/payloads/client_fetch_outfit.json
@@ -18,7 +18,6 @@
                     "rarityIndex": 500,
                     "isNc": true,
                     "isPb": false,
-                    "ncTradeValueText": null,
                     "numUsersOfferingThis": 1,
                     "numUsersSeekingThis": 2
                 },
@@ -30,7 +29,6 @@
                     "rarityIndex": 500,
                     "isNc": true,
                     "isPb": false,
-                    "ncTradeValueText": null,
                     "numUsersOfferingThis": 3,
                     "numUsersSeekingThis": 4
                 },
@@ -42,7 +40,6 @@
                     "rarityIndex": 82,
                     "isNc": false,
                     "isPb": false,
-                    "ncTradeValueText": null,
                     "numUsersOfferingThis": 5,
                     "numUsersSeekingThis": 6
                 },
@@ -54,7 +51,6 @@
                     "rarityIndex": 89,
                     "isNc": false,
                     "isPb": false,
-                    "ncTradeValueText": null,
                     "numUsersOfferingThis": 7,
                     "numUsersSeekingThis": 8
                 },
@@ -66,7 +62,6 @@
                     "rarityIndex": 86,
                     "isNc": false,
                     "isPb": false,
-                    "ncTradeValueText": null,
                     "numUsersOfferingThis": 9,
                     "numUsersSeekingThis": 10
                 },
@@ -78,7 +73,6 @@
                     "rarityIndex": 500,
                     "isNc": true,
                     "isPb": false,
-                    "ncTradeValueText": null,
                     "numUsersOfferingThis": 11,
                     "numUsersSeekingThis": 12
                 }

--- a/tests/payloads/neopet__fetch_assets_for.json
+++ b/tests/payloads/neopet__fetch_assets_for.json
@@ -110,7 +110,6 @@
                 "rarityIndex": 500,
                 "isNc": true,
                 "isPb": false,
-                "ncTradeValueText": null,
                 "numUsersOfferingThis": 1,
                 "numUsersSeekingThis": 2,
                 "appearanceOn": {
@@ -140,7 +139,6 @@
                 "rarityIndex": 500,
                 "isNc": true,
                 "isPb": false,
-                "ncTradeValueText": null,
                 "numUsersOfferingThis": 3,
                 "numUsersSeekingThis": 4,
                 "appearanceOn": {
@@ -176,7 +174,6 @@
                 "rarityIndex": 82,
                 "isNc": false,
                 "isPb": false,
-                "ncTradeValueText": null,
                 "numUsersOfferingThis": 5,
                 "numUsersSeekingThis": 6,
                 "appearanceOn": {
@@ -217,7 +214,6 @@
                 "rarityIndex": 89,
                 "isNc": false,
                 "isPb": false,
-                "ncTradeValueText": null,
                 "numUsersOfferingThis": 7,
                 "numUsersSeekingThis": 8,
                 "appearanceOn": {
@@ -263,7 +259,6 @@
                 "rarityIndex": 86,
                 "isNc": false,
                 "isPb": false,
-                "ncTradeValueText": null,
                 "numUsersOfferingThis": 9,
                 "numUsersSeekingThis": 10,
                 "appearanceOn": {
@@ -293,7 +288,6 @@
                 "rarityIndex": 500,
                 "isNc": true,
                 "isPb": false,
-                "ncTradeValueText": null,
                 "numUsersOfferingThis": 11,
                 "numUsersSeekingThis": 12,
                 "appearanceOn": {

--- a/tests/payloads/neopet__fetch_assets_for__covers_biology.json
+++ b/tests/payloads/neopet__fetch_assets_for__covers_biology.json
@@ -74,7 +74,6 @@
                 "rarityIndex": 87,
                 "isNc": false,
                 "isPb": false,
-                "ncTradeValueText": "None",
                 "numUsersOfferingThis": 1,
                 "numUsersSeekingThis": 2,
                 "appearanceOn": {
@@ -104,7 +103,6 @@
                 "rarityIndex": 87,
                 "isNc": false,
                 "isPb": false,
-                "ncTradeValueText": "None",
                 "numUsersOfferingThis": 3,
                 "numUsersSeekingThis": 4,
                 "appearanceOn": {
@@ -134,7 +132,6 @@
                 "rarityIndex": 87,
                 "isNc": false,
                 "isPb": false,
-                "ncTradeValueText": "None",
                 "numUsersOfferingThis": 5,
                 "numUsersSeekingThis": 6,
                 "appearanceOn": {
@@ -164,7 +161,6 @@
                 "rarityIndex": 87,
                 "isNc": false,
                 "isPb": false,
-                "ncTradeValueText": "None",
                 "numUsersOfferingThis": 7,
                 "numUsersSeekingThis": 8,
                 "appearanceOn": {

--- a/tests/payloads/neopet__fetch_assets_for__unwearable.json
+++ b/tests/payloads/neopet__fetch_assets_for__unwearable.json
@@ -38,7 +38,6 @@
                 "rarityIndex": 500,
                 "isNc": true,
                 "isPb": false,
-                "ncTradeValueText": null,
                 "numUsersOfferingThis": 1,
                 "numUsersSeekingThis": 2,
                 "appearanceOn": {
@@ -68,7 +67,6 @@
                 "rarityIndex": 500,
                 "isNc": true,
                 "isPb": false,
-                "ncTradeValueText": null,
                 "numUsersOfferingThis": 3,
                 "numUsersSeekingThis": 4,
                 "appearanceOn": {


### PR DESCRIPTION
Eliminated the ncTradeValueText field from GraphQL fragments, data models, type definitions, and test payloads. This field is no longer required for item representation or processing.